### PR TITLE
Changed default location of makenek in NekTests.py

### DIFF
--- a/short_tests/lib/nekBinBuild.py
+++ b/short_tests/lib/nekBinBuild.py
@@ -72,8 +72,8 @@ def build_nek(source_root, usr_file, cwd=None, opts=None, verbose=False):
     for key, val in _opts.iteritems():
         print('    Using {0}="{1}"'.format(key, val))
 
-    makenek_in  = os.path.join(source_root, 'core', 'makenek')
-    makenek_out = os.path.join(source_root, 'core', 'makenek.tests')
+    makenek_in  = os.path.join(source_root, 'bin', 'makenek')
+    makenek_out = os.path.join(source_root, 'bin', 'makenek.tests')
     logfile     = os.path.join(cwd, 'compiler.out')
     try:
         config_makenek(

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -112,7 +112,7 @@ class NekTestCase(unittest.TestCase):
 
         self.source_root    = os.path.dirname(os.path.dirname(inspect.getabsfile(self.__class__)))
         self.examples_root  = os.path.dirname(inspect.getabsfile(self.__class__))
-        self.makenek        = os.path.join(self.source_root, 'core', 'makenek')
+        self.makenek        = os.path.join(self.source_root, 'bin', 'makenek')
         self.tools_root     = os.path.join(self.source_root, 'tools')
         self.tools_bin      = os.path.join(self.source_root, 'bin')
         self.log_root       = ""
@@ -181,7 +181,7 @@ class NekTestCase(unittest.TestCase):
         except KeyError:
             pass
         else:
-            self.makenek        = os.path.join(self.source_root, 'core', 'makenek')
+            self.makenek        = os.path.join(self.source_root, 'bin', 'makenek')
             self.tools_root     = os.path.join(self.source_root, 'tools')
             self.tools_bin      = os.path.join(self.source_root, 'bin')
 


### PR DESCRIPTION
This fixes a compatibility issue from [Nek5000 PR #223](https://github.com/Nek5000/Nek5000/pull/223).  That PR moved makenek from core/ to bin/.  However, NekTests.py assumed by default that makenek was in core/.  This PR updates NekTests.py to reflect the new location of makenek.  