### PR TITLE
Updated CI scripts to use new makenek flags

### DIFF
--- a/short_tests/lib/nekFileConfig.py
+++ b/short_tests/lib/nekFileConfig.py
@@ -21,7 +21,7 @@ def config_makenek(opts, infile, outfile):
         lines = f.readlines()
 
     for key, val in opts.iteritems():
-        lines = [re.sub(r'^#*{0}=\"+.*?\"+'.format(key), r'{0}="{1}"'.format(key, val), l) for l in lines]
+        lines = [re.sub(r'^#*{0}=(\"+.*?\"+|\S+)'.format(key), r'{0}="{1}"'.format(key, val), l) for l in lines]
 
     lines = [re.sub(r'(^source\s+\$SOURCE_ROOT/makenek.inc)', r'\g<1> >compiler.out', l)
              for l in lines]

--- a/short_tests/lib/nekTestCase.py
+++ b/short_tests/lib/nekTestCase.py
@@ -317,10 +317,11 @@ class NekTestCase(unittest.TestCase):
         all_opts = dict(
             F77 = self.f77,
             CC = self.cc,
-            G = self.g,
+            FFLAGS = self.g,
+            CFLAGS = self.g,
             PPLIST = self.pplist,
             USR_LFLAGS = self.usr_lflags,
-            IFMPI = str(self.ifmpi).lower(),
+            MPI = int(self.ifmpi),
         )
         if opts:
             all_opts.update(opts)


### PR DESCRIPTION
This should allow the serial Travis tests to pass in https://github.com/Nek5000/Nek5000/pull/240

The issue was that IFMPI was changed to MPI in makenek, and NekTests.py needed to updated accordingly